### PR TITLE
[Fix] NeoForge biome modifier JSONs — fix features completely absent on NeoForge

### DIFF
--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/fire_lily.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/fire_lily.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:structure_gen/fire",
+  "features": "iceandfire:fire_lily",
+  "step": "vegetal_decoration"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/frost_lily.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/frost_lily.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:structure_gen/ice",
+  "features": "iceandfire:frost_lily",
+  "step": "vegetal_decoration"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/lightning_lily.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/lightning_lily.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:structure_gen/lightning",
+  "features": "iceandfire:lightning_lily",
+  "step": "vegetal_decoration"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/sapphire_ore.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/sapphire_ore.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:ore_gen/sapphire",
+  "features": "iceandfire:sapphire_ore",
+  "step": "underground_ores"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/silver_ore.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/silver_ore.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:ore_gen/silver",
+  "features": "iceandfire:silver_ore",
+  "step": "underground_ores"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_death_worm.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_death_worm.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:entity_gen/deathworm",
+  "features": "iceandfire:spawn_death_worm",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_dragon_skeleton_fire.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_dragon_skeleton_fire.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:structure_gen/fire",
+  "features": "iceandfire:spawn_dragon_skeleton_fire",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_dragon_skeleton_ice.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_dragon_skeleton_ice.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:structure_gen/ice",
+  "features": "iceandfire:spawn_dragon_skeleton_ice",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_dragon_skeleton_lightning.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_dragon_skeleton_lightning.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:structure_gen/lightning",
+  "features": "iceandfire:spawn_dragon_skeleton_lightning",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_hippocampus.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_hippocampus.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:entity_gen/hippocampus",
+  "features": "iceandfire:spawn_hippocampus",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_sea_serpent.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_sea_serpent.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:entity_gen/sea_serpent",
+  "features": "iceandfire:spawn_sea_serpent",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_stymphalian_bird.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_stymphalian_bird.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:entity_gen/stymphalian_bird",
+  "features": "iceandfire:spawn_stymphalian_bird",
+  "step": "surface_structures"
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_wandering_cyclops.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_wandering_cyclops.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:entity_gen/wandering_cyclops",
+  "features": "iceandfire:spawn_wandering_cyclops",
+  "step": "surface_structures"
+}


### PR DESCRIPTION
## Problem

`IafFeatures.init()` has an early return on NeoForge:
```java
public static void init() {
    if (Platform.isNeoForge()) return;
    ...
}
```

This means **every** `neoforge:add_features` biome modification was missing on NeoForge — dragon skeletons, death worms, entity spawns, lilies, and ores were all silently absent from any biome.

## Changes

Creates `neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/` with 13 JSON files that mirror the Fabric-side `BiomeModifications` calls exactly:

| File | Biome tag | Feature | Step |
|------|-----------|---------|------|
| `fire_lily.json` | `#iceandfire:structure_gen/fire` | `iceandfire:fire_lily` | `vegetal_decoration` |
| `frost_lily.json` | `#iceandfire:structure_gen/ice` | `iceandfire:frost_lily` | `vegetal_decoration` |
| `lightning_lily.json` | `#iceandfire:structure_gen/lightning` | `iceandfire:lightning_lily` | `vegetal_decoration` |
| `spawn_dragon_skeleton_fire.json` | `#iceandfire:structure_gen/fire` | `iceandfire:spawn_dragon_skeleton_fire` | `surface_structures` |
| `spawn_dragon_skeleton_ice.json` | `#iceandfire:structure_gen/ice` | `iceandfire:spawn_dragon_skeleton_ice` | `surface_structures` |
| `spawn_dragon_skeleton_lightning.json` | `#iceandfire:structure_gen/lightning` | `iceandfire:spawn_dragon_skeleton_lightning` | `surface_structures` |
| `silver_ore.json` | `#iceandfire:ore_gen/silver` | `iceandfire:silver_ore` | `underground_ores` |
| `sapphire_ore.json` | `#iceandfire:ore_gen/sapphire` | `iceandfire:sapphire_ore` | `underground_ores` |
| `spawn_death_worm.json` | `#iceandfire:entity_gen/deathworm` | `iceandfire:spawn_death_worm` | `surface_structures` |
| `spawn_wandering_cyclops.json` | `#iceandfire:entity_gen/wandering_cyclops` | `iceandfire:spawn_wandering_cyclops` | `surface_structures` |
| `spawn_hippocampus.json` | `#iceandfire:entity_gen/hippocampus` | `iceandfire:spawn_hippocampus` | `surface_structures` |
| `spawn_sea_serpent.json` | `#iceandfire:entity_gen/sea_serpent` | `iceandfire:spawn_sea_serpent` | `surface_structures` |
| `spawn_stymphalian_bird.json` | `#iceandfire:entity_gen/stymphalian_bird` | `iceandfire:spawn_stymphalian_bird` | `surface_structures` |

No Java changes — NeoForge loads these modifier JSONs automatically at startup.