### PR TITLE
[Phase 3] Wire dread_ruin and dread_exit_portal into the vanilla structure system

### DIFF
--- a/common/src/main/java/com/iafenvoy/iceandfire/config/IafCommonConfig.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/config/IafCommonConfig.java
@@ -307,6 +307,8 @@ public class IafCommonConfig extends AutoInitConfigContainer {
         public final DoubleEntry generateMausoleumChance = DoubleEntry.builder("config.iceandfire.worldgen.generateMausoleumChance", 0.5).range(0, 1).key("generateMausoleumChance").build();
         public final DoubleEntry generatePixieVillageChance = DoubleEntry.builder("config.iceandfire.worldgen.generatePixieVillageChance", 0.5).range(0, 1).key("generatePixieVillageChance").build();
         public final DoubleEntry generateSirenIslandChance = DoubleEntry.builder("config.iceandfire.worldgen.generateSirenIslandChance", 0.5).range(0, 1).key("generateSirenIslandChance").build();
+        public final DoubleEntry generateDreadRuinChance = DoubleEntry.builder("config.iceandfire.worldgen.generateDreadRuinChance", 0.5).range(0, 1).key("generateDreadRuinChance").build();
+        public final DoubleEntry generateDreadPortalChance = DoubleEntry.builder("config.iceandfire.worldgen.generateDreadPortalChance", 0.2).range(0, 1).key("generateDreadPortalChance").build();
 
         public WorldGenConfig() {
             super("worldgen", "config.iceandfire.category.worldgen");

--- a/common/src/main/java/com/iafenvoy/iceandfire/registry/IafStructureTypes.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/registry/IafStructureTypes.java
@@ -24,6 +24,8 @@ public final class IafStructureTypes {
     public static final RegistrySupplier<StructureType<HydraCaveStructure>> HYDRA_CAVE = registerType("hydra_cave", () -> () -> HydraCaveStructure.CODEC);
     public static final RegistrySupplier<StructureType<SirenIslandStructure>> SIREN_ISLAND = registerType("siren_island", () -> () -> SirenIslandStructure.CODEC);
     public static final RegistrySupplier<StructureType<PixieVillageStructure>> PIXIE_VILLAGE = registerType("pixie_village", () -> () -> PixieVillageStructure.CODEC);
+    public static final RegistrySupplier<StructureType<DreadRuinStructure>> DREAD_RUIN = registerType("dread_ruin", () -> () -> DreadRuinStructure.CODEC);
+    public static final RegistrySupplier<StructureType<DreadPortalStructure>> DREAD_PORTAL = registerType("dread_portal", () -> () -> DreadPortalStructure.CODEC);
 
     private static <P extends Structure> RegistrySupplier<StructureType<P>> registerType(String name, Supplier<StructureType<P>> factory) {
         return REGISTRY.register(name, factory);

--- a/common/src/main/java/com/iafenvoy/iceandfire/registry/tag/IafBiomeTags.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/registry/tag/IafBiomeTags.java
@@ -19,6 +19,8 @@ public final class IafBiomeTags {
     public static final TagKey<Biome> HYDRA_CAVE = create("structure_gen/hydra_cave");
     public static final TagKey<Biome> PIXIE_VILLAGE = create("structure_gen/pixie_village");
     public static final TagKey<Biome> SIREN_ISLAND = create("structure_gen/siren_island");
+    public static final TagKey<Biome> DREAD_RUIN = create("structure_gen/dread_ruin");
+    public static final TagKey<Biome> DREAD_PORTAL = create("structure_gen/dread_portal");
 
     public static final TagKey<Biome> SILVER_ORE = create("ore_gen/silver");
     public static final TagKey<Biome> SAPPHIRE_ORE = create("ore_gen/sapphire");

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DreadPortalStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DreadPortalStructure.java
@@ -1,0 +1,64 @@
+package com.iafenvoy.iceandfire.world.structure;
+
+import com.iafenvoy.iceandfire.config.IafCommonConfig;
+import com.iafenvoy.iceandfire.registry.IafStructureTypes;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.structure.StructureLiquidSettings;
+import net.minecraft.structure.pool.StructurePool;
+import net.minecraft.structure.pool.StructurePoolBasedGenerator;
+import net.minecraft.structure.pool.alias.StructurePoolAliasLookup;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.gen.heightprovider.HeightProvider;
+import net.minecraft.world.gen.structure.DimensionPadding;
+import net.minecraft.world.gen.structure.StructureType;
+
+import java.util.Optional;
+
+public class DreadPortalStructure extends IafJigsawStructure {
+    public static final MapCodec<DreadPortalStructure> CODEC = RecordCodecBuilder.mapCodec(instance ->
+            instance.group(
+                    configCodecBuilder(instance),
+                    StructurePool.REGISTRY_CODEC.fieldOf("start_pool").forGetter(s -> s.startPool),
+                    Identifier.CODEC.optionalFieldOf("start_jigsaw_name").forGetter(s -> s.startJigsawName),
+                    Codec.intRange(0, 30).fieldOf("size").forGetter(s -> s.size),
+                    HeightProvider.CODEC.fieldOf("start_height").forGetter(s -> s.startHeight),
+                    Heightmap.Type.CODEC.optionalFieldOf("project_start_to_heightmap").forGetter(s -> s.projectStartToHeightmap),
+                    Codec.intRange(1, 128).fieldOf("max_distance_from_center").forGetter(s -> s.maxDistanceFromCenter)
+            ).apply(instance, DreadPortalStructure::new));
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public DreadPortalStructure(Config config, RegistryEntry<StructurePool> startPool, Optional<Identifier> startJigsawName,
+                                 int size, HeightProvider startHeight, Optional<Heightmap.Type> projectStartToHeightmap,
+                                 int maxDistanceFromCenter) {
+        super(config, startPool, startJigsawName, size, startHeight, projectStartToHeightmap, maxDistanceFromCenter);
+    }
+
+    @Override
+    protected Optional<StructurePosition> getStructurePosition(Context context) {
+        if (context.random().nextDouble() >= IafCommonConfig.INSTANCE.worldGen.generateDreadPortalChance.getValue())
+            return Optional.empty();
+        BlockPos blockPos = context.chunkPos().getCenterAtY(1);
+        return StructurePoolBasedGenerator.generate(
+                context,
+                this.startPool,
+                this.startJigsawName,
+                this.size,
+                blockPos,
+                false,
+                this.projectStartToHeightmap,
+                this.maxDistanceFromCenter,
+                StructurePoolAliasLookup.EMPTY,
+                DimensionPadding.NONE,
+                StructureLiquidSettings.IGNORE_WATERLOGGING);
+    }
+
+    @Override
+    public StructureType<?> getType() {
+        return IafStructureTypes.DREAD_PORTAL.get();
+    }
+}

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DreadRuinStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/DreadRuinStructure.java
@@ -1,0 +1,64 @@
+package com.iafenvoy.iceandfire.world.structure;
+
+import com.iafenvoy.iceandfire.config.IafCommonConfig;
+import com.iafenvoy.iceandfire.registry.IafStructureTypes;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.structure.StructureLiquidSettings;
+import net.minecraft.structure.pool.StructurePool;
+import net.minecraft.structure.pool.StructurePoolBasedGenerator;
+import net.minecraft.structure.pool.alias.StructurePoolAliasLookup;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.gen.heightprovider.HeightProvider;
+import net.minecraft.world.gen.structure.DimensionPadding;
+import net.minecraft.world.gen.structure.StructureType;
+
+import java.util.Optional;
+
+public class DreadRuinStructure extends IafJigsawStructure {
+    public static final MapCodec<DreadRuinStructure> CODEC = RecordCodecBuilder.mapCodec(instance ->
+            instance.group(
+                    configCodecBuilder(instance),
+                    StructurePool.REGISTRY_CODEC.fieldOf("start_pool").forGetter(s -> s.startPool),
+                    Identifier.CODEC.optionalFieldOf("start_jigsaw_name").forGetter(s -> s.startJigsawName),
+                    Codec.intRange(0, 30).fieldOf("size").forGetter(s -> s.size),
+                    HeightProvider.CODEC.fieldOf("start_height").forGetter(s -> s.startHeight),
+                    Heightmap.Type.CODEC.optionalFieldOf("project_start_to_heightmap").forGetter(s -> s.projectStartToHeightmap),
+                    Codec.intRange(1, 128).fieldOf("max_distance_from_center").forGetter(s -> s.maxDistanceFromCenter)
+            ).apply(instance, DreadRuinStructure::new));
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public DreadRuinStructure(Config config, RegistryEntry<StructurePool> startPool, Optional<Identifier> startJigsawName,
+                               int size, HeightProvider startHeight, Optional<Heightmap.Type> projectStartToHeightmap,
+                               int maxDistanceFromCenter) {
+        super(config, startPool, startJigsawName, size, startHeight, projectStartToHeightmap, maxDistanceFromCenter);
+    }
+
+    @Override
+    protected Optional<StructurePosition> getStructurePosition(Context context) {
+        if (context.random().nextDouble() >= IafCommonConfig.INSTANCE.worldGen.generateDreadRuinChance.getValue())
+            return Optional.empty();
+        BlockPos blockPos = context.chunkPos().getCenterAtY(1);
+        return StructurePoolBasedGenerator.generate(
+                context,
+                this.startPool,
+                this.startJigsawName,
+                this.size,
+                blockPos,
+                false,
+                this.projectStartToHeightmap,
+                this.maxDistanceFromCenter,
+                StructurePoolAliasLookup.EMPTY,
+                DimensionPadding.NONE,
+                StructureLiquidSettings.IGNORE_WATERLOGGING);
+    }
+
+    @Override
+    public StructureType<?> getType() {
+        return IafStructureTypes.DREAD_RUIN.get();
+    }
+}

--- a/common/src/main/resources/data/iceandfire/tags/worldgen/biome/structure_gen/dread_portal.json
+++ b/common/src/main/resources/data/iceandfire/tags/worldgen/biome/structure_gen/dread_portal.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "iceandfire:dread_forest",
+    "iceandfire:dread_plain"
+  ]
+}

--- a/common/src/main/resources/data/iceandfire/tags/worldgen/biome/structure_gen/dread_ruin.json
+++ b/common/src/main/resources/data/iceandfire/tags/worldgen/biome/structure_gen/dread_ruin.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "iceandfire:dread_forest",
+    "iceandfire:dread_plain"
+  ]
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/processor_list/dread_portal_processors.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/processor_list/dread_portal_processors.json
@@ -1,0 +1,7 @@
+{
+  "processors": [
+    {
+      "processor_type": "iceandfire:dread_portal_processor"
+    }
+  ]
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/processor_list/dread_ruin_processors.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/processor_list/dread_ruin_processors.json
@@ -1,0 +1,7 @@
+{
+  "processors": [
+    {
+      "processor_type": "iceandfire:dread_mausoleum_processor"
+    }
+  ]
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/structure/dread_portal.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/structure/dread_portal.json
@@ -1,0 +1,14 @@
+{
+  "type": "iceandfire:dread_portal",
+  "biomes": "#iceandfire:structure_gen/dread_portal",
+  "max_distance_from_center": 16,
+  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "size": 1,
+  "spawn_overrides": {},
+  "start_height": {
+    "absolute": 0
+  },
+  "start_pool": "iceandfire:dread_portal/start_pool",
+  "step": "surface_structures",
+  "terrain_adaptation": "beard_thin"
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/structure/dread_ruin.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/structure/dread_ruin.json
@@ -1,0 +1,14 @@
+{
+  "type": "iceandfire:dread_ruin",
+  "biomes": "#iceandfire:structure_gen/dread_ruin",
+  "max_distance_from_center": 16,
+  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "size": 1,
+  "spawn_overrides": {},
+  "start_height": {
+    "absolute": 0
+  },
+  "start_pool": "iceandfire:dread_ruin/start_pool",
+  "step": "surface_structures",
+  "terrain_adaptation": "beard_thin"
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/structure_set/dread_portal.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/structure_set/dread_portal.json
@@ -1,0 +1,14 @@
+{
+  "placement": {
+    "type": "minecraft:random_spread",
+    "salt": 51836794,
+    "separation": 16,
+    "spacing": 40
+  },
+  "structures": [
+    {
+      "structure": "iceandfire:dread_portal",
+      "weight": 1
+    }
+  ]
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/structure_set/dread_ruin.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/structure_set/dread_ruin.json
@@ -1,0 +1,14 @@
+{
+  "placement": {
+    "type": "minecraft:random_spread",
+    "salt": 73951482,
+    "separation": 8,
+    "spacing": 16
+  },
+  "structures": [
+    {
+      "structure": "iceandfire:dread_ruin",
+      "weight": 1
+    }
+  ]
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/template_pool/dread_portal/start_pool.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/template_pool/dread_portal/start_pool.json
@@ -1,0 +1,14 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_exit_portal",
+        "processors": "iceandfire:dread_portal_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    }
+  ],
+  "fallback": "minecraft:empty"
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/template_pool/dread_ruin/start_pool.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/template_pool/dread_ruin/start_pool.json
@@ -1,0 +1,122 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_0",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_1",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_2",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_3",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_4",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_5",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_6",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_7",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_8",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_9",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_10",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_11",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:single_pool_element",
+        "location": "iceandfire:dread_ruin_12",
+        "processors": "iceandfire:dread_ruin_processors",
+        "projection": "rigid"
+      },
+      "weight": 1
+    }
+  ],
+  "fallback": "minecraft:empty"
+}


### PR DESCRIPTION
## Problem

The 13 `dread_ruin_*.nbt` templates and `dread_exit_portal.nbt`, plus both dread processors (`DreadRuinProcessor`, `DreadPortalProcessor`), existed in the codebase but were never wired into the vanilla worldgen structure system. No `Structure` subclass, no template pools, no structure/structure_set JSONs — meaning dread ruins and the exit portal never generated at all.

## Changes

### Java
- **`DreadRuinStructure`** — `IafJigsawStructure` subclass; picks one of 13 ruin templates randomly via the template pool; respects `generateDreadRuinChance` config (default 0.5)
- **`DreadPortalStructure`** — same pattern for the single exit portal template; respects `generateDreadPortalChance` config (default 0.2, intentionally rarer)
- **`IafStructureTypes`** — registered `dread_ruin` and `dread_portal` types
- **`IafBiomeTags`** — added `DREAD_RUIN` and `DREAD_PORTAL` tags (`structure_gen/dread_ruin`, `structure_gen/dread_portal`)
- **`IafCommonConfig.WorldGenConfig`** — added `generateDreadRuinChance` and `generateDreadPortalChance` entries

### Data
| File | Purpose |
|------|---------|
| `processor_list/dread_ruin_processors.json` | References `dread_mausoleum_processor` for block cracking |
| `processor_list/dread_portal_processors.json` | References `dread_portal_processor` |
| `template_pool/dread_ruin/start_pool.json` | All 13 variants (`dread_ruin_0` – `dread_ruin_12`) with equal weight |
| `template_pool/dread_portal/start_pool.json` | Single `dread_exit_portal` element |
| `structure/dread_ruin.json` | `iceandfire:dread_ruin`, biome tag `structure_gen/dread_ruin` |
| `structure/dread_portal.json` | `iceandfire:dread_portal`, biome tag `structure_gen/dread_portal` |
| `structure_set/dread_ruin.json` | `random_spread`, spacing=16/separation=8, salt unique |
| `structure_set/dread_portal.json` | `random_spread`, spacing=40/separation=16 (rarer), salt unique |
| `tags/worldgen/biome/structure_gen/dread_ruin.json` | `dread_forest` + `dread_plain` |
| `tags/worldgen/biome/structure_gen/dread_portal.json` | `dread_forest` + `dread_plain` |