### PR TITLE
feat: amphithere chunk-generation spawn feature

### DIFF
--- a/common/src/main/java/com/iafenvoy/iceandfire/entity/AmphithereEntity.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/entity/AmphithereEntity.java
@@ -554,7 +554,6 @@ public class AmphithereEntity extends TameableEntity implements ISyncMount, IAni
         this.setConfigurableAttributes();
     }
 
-    //TODO: Create entity placements
     public boolean getCanSpawnHere() {
         int i = MathHelper.floor(this.getX());
         int j = MathHelper.floor(this.getBoundingBox().minY);

--- a/common/src/main/java/com/iafenvoy/iceandfire/registry/IafFeatures.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/registry/IafFeatures.java
@@ -5,6 +5,7 @@ import com.iafenvoy.iceandfire.registry.tag.IafBiomeTags;
 import com.iafenvoy.iceandfire.world.feature.*;
 import com.iafenvoy.iceandfire.world.feature.config.DeathWormFeatureConfig;
 import com.iafenvoy.iceandfire.world.feature.config.DragonSkeletonFeatureConfig;
+import com.iafenvoy.iceandfire.world.feature.config.EntitySpawnFeatureConfig;
 import com.iafenvoy.iceandfire.world.feature.config.HippocampusFeatureConfig;
 import com.iafenvoy.iceandfire.world.feature.config.SeaSerpentFeatureConfig;
 import com.iafenvoy.iceandfire.world.feature.config.StymphalianBirdFeatureConfig;
@@ -27,6 +28,7 @@ import java.util.function.Supplier;
 public final class IafFeatures {
     public static final DeferredRegister<Feature<?>> REGISTRY = DeferredRegister.create(IceAndFire.MOD_ID, RegistryKeys.FEATURE);
 
+    public static final RegistrySupplier<Feature<EntitySpawnFeatureConfig>> SPAWN_AMPHITHERE = feature("spawn_amphithere", AmphithereSpawnFeature::new);
     public static final RegistrySupplier<Feature<DeathWormFeatureConfig>> SPAWN_DEATH_WORM = feature("spawn_death_worm", DeathWormSpawnFeature::new);
     public static final RegistrySupplier<Feature<DragonSkeletonFeatureConfig>> SPAWN_DRAGON_SKELETON = feature("spawn_dragon_skeleton", DragonSkeletonSpawnFeature::new);
     public static final RegistrySupplier<Feature<HippocampusFeatureConfig>> SPAWN_HIPPOCAMPUS = feature("spawn_hippocampus", HippocampusSpawnFeature::new);
@@ -41,6 +43,7 @@ public final class IafFeatures {
     public static final RegistryKey<ConfiguredFeature<?, ?>> DREADWOOD = configuredFeature("dreadwood");
     public static final RegistryKey<ConfiguredFeature<?, ?>> DREADWOOD_LARGE = configuredFeature("dreadwood_large");
 
+    public static final RegistryKey<PlacedFeature> PLACED_SPAWN_AMPHITHERE = placeFeature("spawn_amphithere");
     public static final RegistryKey<PlacedFeature> PLACED_SPAWN_DEATH_WORM = placeFeature("spawn_death_worm");
     public static final RegistryKey<PlacedFeature> PLACED_SPAWN_DRAGON_SKELETON_L = placeFeature("spawn_dragon_skeleton_lightning");
     public static final RegistryKey<PlacedFeature> PLACED_SPAWN_DRAGON_SKELETON_F = placeFeature("spawn_dragon_skeleton_fire");
@@ -77,6 +80,7 @@ public final class IafFeatures {
         addFeatureToBiome(IafBiomeTags.SAPPHIRE_ORE, PLACED_SAPPHIRE_ORE, GenerationStep.Feature.UNDERGROUND_ORES);
 
         addFeatureToBiome(IafBiomeTags.DEATHWORM, PLACED_SPAWN_DEATH_WORM, GenerationStep.Feature.SURFACE_STRUCTURES);
+        addFeatureToBiome(IafBiomeTags.AMPHITHERE, PLACED_SPAWN_AMPHITHERE, GenerationStep.Feature.SURFACE_STRUCTURES);
         addFeatureToBiome(IafBiomeTags.WANDERING_CYCLOPS, PLACED_SPAWN_WANDERING_CYCLOPS, GenerationStep.Feature.SURFACE_STRUCTURES);
         addFeatureToBiome(IafBiomeTags.HIPPOCAMPUS, PLACED_SPAWN_HIPPOCAMPUS, GenerationStep.Feature.SURFACE_STRUCTURES);
         addFeatureToBiome(IafBiomeTags.SEA_SERPENT, PLACED_SPAWN_SEA_SERPENT, GenerationStep.Feature.SURFACE_STRUCTURES);

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/feature/AmphithereSpawnFeature.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/feature/AmphithereSpawnFeature.java
@@ -1,0 +1,34 @@
+package com.iafenvoy.iceandfire.world.feature;
+
+import com.iafenvoy.iceandfire.world.DangerousGeneration;
+import com.iafenvoy.iceandfire.world.feature.config.EntitySpawnFeatureConfig;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.MobEntity;
+import net.minecraft.entity.SpawnReason;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.StructureWorldAccess;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+public class AmphithereSpawnFeature extends Feature<EntitySpawnFeatureConfig> implements DangerousGeneration {
+    public AmphithereSpawnFeature() {
+        super(EntitySpawnFeatureConfig.CODEC);
+    }
+
+    @Override
+    public boolean generate(FeatureContext<EntitySpawnFeatureConfig> context) {
+        StructureWorldAccess world = context.getWorld();
+        BlockPos pos = world.getTopPosition(Heightmap.Type.WORLD_SURFACE_WG, context.getOrigin().add(8, 0, 8));
+        if (this.isFarEnoughFromSpawn(world, pos) && context.getRandom().nextDouble() < context.getConfig().spawnChance()) {
+            Entity entity = context.getConfig().entityType().create(world.toServerWorld());
+            if (entity != null) {
+                entity.setPosition(pos.getX() + 0.5F, pos.getY() + 1, pos.getZ() + 0.5F);
+                if (entity instanceof MobEntity mob)
+                    mob.initialize(world, world.getLocalDifficulty(pos), SpawnReason.CHUNK_GENERATION, null);
+                world.spawnEntity(entity);
+            }
+        }
+        return true;
+    }
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/configured_feature/spawn_amphithere.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/configured_feature/spawn_amphithere.json
@@ -1,0 +1,7 @@
+{
+  "type": "iceandfire:spawn_amphithere",
+  "config": {
+    "spawn_chance": 0.033,
+    "entity_type": "iceandfire:amphithere"
+  }
+}

--- a/common/src/main/resources/data/iceandfire/worldgen/placed_feature/spawn_amphithere.json
+++ b/common/src/main/resources/data/iceandfire/worldgen/placed_feature/spawn_amphithere.json
@@ -1,0 +1,12 @@
+{
+  "feature": "iceandfire:spawn_amphithere",
+  "placement": [
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "WORLD_SURFACE_WG"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_amphithere.json
+++ b/neoforge/src/main/resources/data/iceandfire/neoforge/biome_modifier/spawn_amphithere.json
@@ -1,0 +1,6 @@
+{
+  "type": "neoforge:add_features",
+  "biomes": "#iceandfire:entity_gen/amphithere",
+  "features": "iceandfire:spawn_amphithere",
+  "step": "surface_structures"
+}


### PR DESCRIPTION
## Summary

Implements the Amphithere world-generation spawn feature — the last outstanding entity-spawn gap from the world-gen rewrite plan.

## Changes

| File | Change |
|---|---|
| `AmphithereSpawnFeature.java` | New `Feature<EntitySpawnFeatureConfig>` implementing `DangerousGeneration`; mirrors `DeathWormSpawnFeature` pattern |
| `IafFeatures.java` | Register `SPAWN_AMPHITHERE` feature + `PLACED_SPAWN_AMPHITHERE` key; add `EntitySpawnFeatureConfig` import; wire `IafBiomeTags.AMPHITHERE` into Fabric `init()` |
| `configured_feature/spawn_amphithere.json` | `spawn_chance: 0.033`, `entity_type: iceandfire:amphithere` |
| `placed_feature/spawn_amphithere.json` | `WORLD_SURFACE_WG` heightmap + `minecraft:biome` placements |
| `neoforge/biome_modifier/spawn_amphithere.json` | `neoforge:add_features` targeting `#iceandfire:entity_gen/amphithere`, step `surface_structures` |
| `AmphithereEntity.java` | Removed resolved `//TODO: Create entity placements` comment |

## Design notes

- Reuses the existing `EntitySpawnFeatureConfig` (generic `spawnChance` + `entityType` record) instead of adding a redundant `AmphithereFeatureConfig`.
- `entity_gen/amphithere.json` biome tag already exists targeting `#minecraft:is_jungle` — no tag changes needed.
- Spawn chance `0.033` matches the Death Worm baseline; Amphitheres are surface jungle creatures of comparable rarity.