### PR TITLE
[Phase 2] Shared infrastructure for data-driven procedural structure configs

### DIFF
--- a/common/src/main/java/com/iafenvoy/iceandfire/world/StructureGenerationConfig.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/StructureGenerationConfig.java
@@ -1,0 +1,15 @@
+package com.iafenvoy.iceandfire.world;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+public record StructureGenerationConfig(float generateChance) {
+    public static final StructureGenerationConfig DEFAULT = new StructureGenerationConfig(0.5f);
+
+    public static final Codec<StructureGenerationConfig> CODEC = RecordCodecBuilder.create(i ->
+            i.group(
+                    Codec.floatRange(0f, 1f)
+                            .optionalFieldOf("generate_chance", 0.5f)
+                            .forGetter(StructureGenerationConfig::generateChance)
+            ).apply(i, StructureGenerationConfig::new));
+}

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/CyclopsCaveStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/CyclopsCaveStructure.java
@@ -1,7 +1,6 @@
 package com.iafenvoy.iceandfire.world.structure;
 
 import com.iafenvoy.iceandfire.IceAndFire;
-import com.iafenvoy.iceandfire.config.IafCommonConfig;
 import com.iafenvoy.iceandfire.entity.CyclopsEntity;
 import com.iafenvoy.iceandfire.item.block.PileBlock;
 import com.iafenvoy.iceandfire.registry.IafBlocks;
@@ -9,6 +8,7 @@ import com.iafenvoy.iceandfire.registry.IafEntities;
 import com.iafenvoy.iceandfire.registry.IafStructurePieces;
 import com.iafenvoy.iceandfire.registry.IafStructureTypes;
 import com.iafenvoy.iceandfire.world.DangerousGeneration;
+import com.iafenvoy.iceandfire.world.StructureGenerationConfig;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.block.*;
@@ -42,16 +42,23 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class CyclopsCaveStructure extends Structure implements DangerousGeneration {
-    public static final MapCodec<CyclopsCaveStructure> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(configCodecBuilder(instance)).apply(instance, CyclopsCaveStructure::new));
+    public static final MapCodec<CyclopsCaveStructure> CODEC = RecordCodecBuilder.mapCodec(instance ->
+            instance.group(configCodecBuilder(instance),
+                    StructureGenerationConfig.CODEC.optionalFieldOf("generation", StructureGenerationConfig.DEFAULT)
+                            .forGetter(s -> s.generationConfig)
+            ).apply(instance, CyclopsCaveStructure::new));
 
-    protected CyclopsCaveStructure(Config config) {
+    private final StructureGenerationConfig generationConfig;
+
+    protected CyclopsCaveStructure(Config config, StructureGenerationConfig generationConfig) {
         super(config);
+        this.generationConfig = generationConfig;
     }
 
     @SuppressWarnings("deprecation")
     @Override
     protected Optional<StructurePosition> getStructurePosition(Context context) {
-        if (context.random().nextDouble() >= IafCommonConfig.INSTANCE.worldGen.generateCyclopsCaveChance.getValue())
+        if (context.random().nextDouble() >= this.generationConfig.generateChance())
             return Optional.empty();
         BlockRotation blockRotation = BlockRotation.random(context.random());
         BlockPos blockPos = this.getShiftedPos(context, blockRotation);

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/HydraCaveStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/HydraCaveStructure.java
@@ -1,12 +1,12 @@
 package com.iafenvoy.iceandfire.world.structure;
 
 import com.iafenvoy.iceandfire.IceAndFire;
-import com.iafenvoy.iceandfire.config.IafCommonConfig;
 import com.iafenvoy.iceandfire.entity.HydraEntity;
 import com.iafenvoy.iceandfire.registry.IafEntities;
 import com.iafenvoy.iceandfire.registry.IafStructurePieces;
 import com.iafenvoy.iceandfire.registry.IafStructureTypes;
 import com.iafenvoy.iceandfire.world.DangerousGeneration;
+import com.iafenvoy.iceandfire.world.StructureGenerationConfig;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.block.Blocks;
@@ -39,16 +39,23 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class HydraCaveStructure extends Structure implements DangerousGeneration {
-    public static final MapCodec<HydraCaveStructure> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(configCodecBuilder(instance)).apply(instance, HydraCaveStructure::new));
+    public static final MapCodec<HydraCaveStructure> CODEC = RecordCodecBuilder.mapCodec(instance ->
+            instance.group(configCodecBuilder(instance),
+                    StructureGenerationConfig.CODEC.optionalFieldOf("generation", StructureGenerationConfig.DEFAULT)
+                            .forGetter(s -> s.generationConfig)
+            ).apply(instance, HydraCaveStructure::new));
 
-    protected HydraCaveStructure(Config config) {
+    private final StructureGenerationConfig generationConfig;
+
+    protected HydraCaveStructure(Config config, StructureGenerationConfig generationConfig) {
         super(config);
+        this.generationConfig = generationConfig;
     }
 
     @SuppressWarnings("deprecation")
     @Override
     protected Optional<StructurePosition> getStructurePosition(Context context) {
-        if (context.random().nextDouble() >= IafCommonConfig.INSTANCE.worldGen.generateHydraCaveChance.getValue())
+        if (context.random().nextDouble() >= this.generationConfig.generateChance())
             return Optional.empty();
         BlockRotation blockRotation = BlockRotation.random(context.random());
         BlockPos blockPos = this.getShiftedPos(context, blockRotation);

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/PixieVillageStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/PixieVillageStructure.java
@@ -1,12 +1,12 @@
 package com.iafenvoy.iceandfire.world.structure;
 
-import com.iafenvoy.iceandfire.config.IafCommonConfig;
 import com.iafenvoy.iceandfire.entity.PixieEntity;
 import com.iafenvoy.iceandfire.item.block.PixieHouseBlock;
 import com.iafenvoy.iceandfire.registry.IafBlocks;
 import com.iafenvoy.iceandfire.registry.IafEntities;
 import com.iafenvoy.iceandfire.registry.IafStructurePieces;
 import com.iafenvoy.iceandfire.registry.IafStructureTypes;
+import com.iafenvoy.iceandfire.world.StructureGenerationConfig;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.block.BlockState;
@@ -34,16 +34,22 @@ import java.util.Optional;
 
 public class PixieVillageStructure extends Structure {
     public static final MapCodec<PixieVillageStructure> CODEC = RecordCodecBuilder.mapCodec(instance ->
-            instance.group(configCodecBuilder(instance)).apply(instance, PixieVillageStructure::new));
+            instance.group(configCodecBuilder(instance),
+                    StructureGenerationConfig.CODEC.optionalFieldOf("generation", StructureGenerationConfig.DEFAULT)
+                            .forGetter(s -> s.generationConfig)
+            ).apply(instance, PixieVillageStructure::new));
 
-    protected PixieVillageStructure(Config config) {
+    private final StructureGenerationConfig generationConfig;
+
+    protected PixieVillageStructure(Config config, StructureGenerationConfig generationConfig) {
         super(config);
+        this.generationConfig = generationConfig;
     }
 
     @SuppressWarnings("deprecation")
     @Override
     protected Optional<StructurePosition> getStructurePosition(Context context) {
-        if (context.random().nextDouble() >= IafCommonConfig.INSTANCE.worldGen.generatePixieVillageChance.getValue())
+        if (context.random().nextDouble() >= this.generationConfig.generateChance())
             return Optional.empty();
         BlockRotation blockRotation = BlockRotation.random(context.random());
         BlockPos blockPos = this.getShiftedPos(context, blockRotation);

--- a/common/src/main/java/com/iafenvoy/iceandfire/world/structure/SirenIslandStructure.java
+++ b/common/src/main/java/com/iafenvoy/iceandfire/world/structure/SirenIslandStructure.java
@@ -1,11 +1,11 @@
 package com.iafenvoy.iceandfire.world.structure;
 
-import com.iafenvoy.iceandfire.config.IafCommonConfig;
 import com.iafenvoy.iceandfire.entity.SirenEntity;
 import com.iafenvoy.iceandfire.registry.IafEntities;
 import com.iafenvoy.iceandfire.registry.IafStructurePieces;
 import com.iafenvoy.iceandfire.registry.IafStructureTypes;
 import com.iafenvoy.iceandfire.world.DangerousGeneration;
+import com.iafenvoy.iceandfire.world.StructureGenerationConfig;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.block.Block;
@@ -31,16 +31,22 @@ import java.util.Optional;
 
 public class SirenIslandStructure extends Structure implements DangerousGeneration {
     public static final MapCodec<SirenIslandStructure> CODEC = RecordCodecBuilder.mapCodec(instance ->
-            instance.group(configCodecBuilder(instance)).apply(instance, SirenIslandStructure::new));
+            instance.group(configCodecBuilder(instance),
+                    StructureGenerationConfig.CODEC.optionalFieldOf("generation", StructureGenerationConfig.DEFAULT)
+                            .forGetter(s -> s.generationConfig)
+            ).apply(instance, SirenIslandStructure::new));
 
-    protected SirenIslandStructure(Config config) {
+    private final StructureGenerationConfig generationConfig;
+
+    protected SirenIslandStructure(Config config, StructureGenerationConfig generationConfig) {
         super(config);
+        this.generationConfig = generationConfig;
     }
 
     @SuppressWarnings("deprecation")
     @Override
     protected Optional<StructurePosition> getStructurePosition(Context context) {
-        if (context.random().nextDouble() >= IafCommonConfig.INSTANCE.worldGen.generateSirenIslandChance.getValue())
+        if (context.random().nextDouble() >= this.generationConfig.generateChance())
             return Optional.empty();
         BlockRotation blockRotation = BlockRotation.random(context.random());
         BlockPos blockPos = this.getShiftedPos(context, blockRotation);


### PR DESCRIPTION
## Summary

Adds `StructureGenerationConfig` — a Codec-backed record that makes `generate_chance` data-driven for four structures that previously hard-coded their chance against `IafCommonConfig`.

### Changes
- **New**: `world/StructureGenerationConfig.java` — `{ "generate_chance": float [0,1] }` optional JSON field, defaults to `0.5`
- **Updated**: `CyclopsCaveStructure`, `HydraCaveStructure`, `PixieVillageStructure`, `SirenIslandStructure` — each now carries a `generationConfig` field wired through its CODEC; spawn rate is read from the JSON structure config instead of `IafCommonConfig`

### What was intentionally excluded (vs original PR #19)
- `world/BlockTransformRule.java` — duplicate; canonical copy already lives at `world/structure/BlockTransformRule.java` (merged with PR #18)
- `DangerousGeneration` change to abstract `double` — kept as `default float`; the global config default is sufficient and avoids forcing every implementor to override
- `getDangerousRadius()` overrides on Gorgon/Mausoleum/spawn features — unnecessary given the restored default
- All Dragon Cave / Roost subclass changes — obsolete after PRs #18 and #20

Closes #19